### PR TITLE
URL Cleanup

### DIFF
--- a/node_modules/socket.io/support/expresso/deps/jscoverage/tests/proxy.sh
+++ b/node_modules/socket.io/support/expresso/deps/jscoverage/tests/proxy.sh
@@ -91,14 +91,14 @@ wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' http://127.0.0.1:8000/1/2/2.j
 cat ../report.js recursive.expected/1/2/2.js | sed 's/@PREFIX@/http:\/\/127.0.0.1:8000\//g' | diff --strip-trailing-cr - OUT
 
 ## test jscoverage
-wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' http://siliconforks.com/jscoverage.html | diff ../jscoverage.html -
-wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' http://siliconforks.com/jscoverage.css | diff ../jscoverage.css -
-wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' http://siliconforks.com/jscoverage-throbber.gif | diff ../jscoverage-throbber.gif -
-wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' http://siliconforks.com/jscoverage.js > OUT
+wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' https://siliconforks.com/jscoverage.html | diff ../jscoverage.html -
+wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' https://siliconforks.com/jscoverage.css | diff ../jscoverage.css -
+wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' https://siliconforks.com/jscoverage-throbber.gif | diff ../jscoverage-throbber.gif -
+wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' https://siliconforks.com/jscoverage.js > OUT
 echo -e 'jscoverage_isServer = true;\r' | cat ../jscoverage.js - | diff - OUT
 
 # load/store
-wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' --post-data='{}' http://siliconforks.com/jscoverage-store > /dev/null
+wget -q -O- -e 'http_proxy=http://127.0.0.1:8080/' --post-data='{}' https://siliconforks.com/jscoverage-store > /dev/null
 echo -n '{}' | diff - DIR/jscoverage.json
 diff ../jscoverage.html DIR/jscoverage.html
 diff ../jscoverage.css DIR/jscoverage.css
@@ -112,7 +112,7 @@ diff EXPECTED ACTUAL
 
 # nonexistent domain
 echo 504 > EXPECTED
-! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 http://nonexistent 2> /dev/null > ACTUAL
+! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 https://nonexistent 2> /dev/null > ACTUAL
 diff EXPECTED ACTUAL
 
 # 404 not found
@@ -120,7 +120,7 @@ echo 404 > EXPECTED
 ! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 http://127.0.0.1:8000/missing 2> /dev/null > ACTUAL
 diff EXPECTED ACTUAL
 echo 404 > EXPECTED
-! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 http://siliconforks.com/jscoverage-missing 2> /dev/null > ACTUAL
+! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 https://siliconforks.com/jscoverage-missing 2> /dev/null > ACTUAL
 diff EXPECTED ACTUAL
 
 ## send it a server request

--- a/node_modules/socket.io/support/expresso/deps/jscoverage/tests/server.sh
+++ b/node_modules/socket.io/support/expresso/deps/jscoverage/tests/server.sh
@@ -107,7 +107,7 @@ diff EXPECTED ACTUAL
 
 ## send it a proxy request
 #echo 400 > EXPECTED
-#! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 http://siliconforks.com/ 2> /dev/null > ACTUAL
+#! curl -f -w '%{http_code}\n' -x 127.0.0.1:8080 https://siliconforks.com/ 2> /dev/null > ACTUAL
 #diff EXPECTED ACTUAL
 
 # kill $server_pid


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://opensource.adobe.com/wiki/display/flexsdk/Download+Flex+4 (404) migrated to:  
  http://opensource.adobe.com/wiki/display/flexsdk/Download+Flex+4 ([https](https://opensource.adobe.com/wiki/display/flexsdk/Download+Flex+4) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://nonexistent (UnknownHostException) migrated to:  
  https://nonexistent ([https](https://nonexistent) result UnknownHostException).
* http://siliconforks.com/jscoverage-missing (404) migrated to:  
  https://siliconforks.com/jscoverage-missing ([https](https://siliconforks.com/jscoverage-missing) result 404).
* http://siliconforks.com/jscoverage-store (404) migrated to:  
  https://siliconforks.com/jscoverage-store ([https](https://siliconforks.com/jscoverage-store) result 404).
* http://siliconforks.com/jscoverage-throbber.gif (404) migrated to:  
  https://siliconforks.com/jscoverage-throbber.gif ([https](https://siliconforks.com/jscoverage-throbber.gif) result 404).
* http://siliconforks.com/jscoverage.css (404) migrated to:  
  https://siliconforks.com/jscoverage.css ([https](https://siliconforks.com/jscoverage.css) result 404).
* http://siliconforks.com/jscoverage.html (404) migrated to:  
  https://siliconforks.com/jscoverage.html ([https](https://siliconforks.com/jscoverage.html) result 404).
* http://siliconforks.com/jscoverage.js (404) migrated to:  
  https://siliconforks.com/jscoverage.js ([https](https://siliconforks.com/jscoverage.js) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://siliconforks.com/ migrated to:  
  https://siliconforks.com/ ([https](https://siliconforks.com/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://127.0.0.1
* http://127.0.0.1:/index.html
* http://127.0.0.1:1/index.html
* http://127.0.0.1:123456/index.html
* http://127.0.0.1:8000
* http://127.0.0.1:8000/
* http://127.0.0.1:8000/1/
* http://127.0.0.1:8000/1/1.css
* http://127.0.0.1:8000/1/1.html
* http://127.0.0.1:8000/1/1.js
* http://127.0.0.1:8000/1/2/2.css
* http://127.0.0.1:8000/1/2/2.html
* http://127.0.0.1:8000/1/2/2.js
* http://127.0.0.1:8000/bogus.js
* http://127.0.0.1:8000/image.png
* http://127.0.0.1:8000/index.html
* http://127.0.0.1:8000/index.html?foo
* http://127.0.0.1:8000/iso-8859-1.js
* http://127.0.0.1:8000/javascript
* http://127.0.0.1:8000/jscoverage-store
* http://127.0.0.1:8000/lower
* http://127.0.0.1:8000/malformed.js
* http://127.0.0.1:8000/missing
* http://127.0.0.1:8000/multiple
* http://127.0.0.1:8000/overflow
* http://127.0.0.1:8000/perl-shutdown
* http://127.0.0.1:8000/script.js
* http://127.0.0.1:8000/style.css
* http://127.0.0.1:8000/trailer
* http://127.0.0.1:8000/unix.txt
* http://127.0.0.1:8000/upper
* http://127.0.0.1:8000/utf-8.js
* http://127.0.0.1:8000/windows.txt
* http://127.0.0.1:8000/x
* http://127.0.0.1:8000?foo
* http://127.0.0.1:8080/
* http://127.0.0.1:8080/../Makefile.am
* http://127.0.0.1:8080/1
* http://127.0.0.1:8080/1%202.txt
* http://127.0.0.1:8080/1%262.txt
* http://127.0.0.1:8080/1%2B2.txt
* http://127.0.0.1:8080/1%2b2.txt
* http://127.0.0.1:8080/1/1.css
* http://127.0.0.1:8080/1/1.html
* http://127.0.0.1:8080/1/1.js
* http://127.0.0.1:8080/1/2/2.css
* http://127.0.0.1:8080/1/2/2.html
* http://127.0.0.1:8080/1/2/2.js
* http://127.0.0.1:8080/DIR/
* http://127.0.0.1:8080/DIR/foo
* http://127.0.0.1:8080/DIR/index.html
* http://127.0.0.1:8080/image.png
* http://127.0.0.1:8080/index.html
* http://127.0.0.1:8080/index.html?foo
* http://127.0.0.1:8080/javascript-iso-8859-1.js
* http://127.0.0.1:8080/javascript-utf-8.js
* http://127.0.0.1:8080/jscoverage-missing
* http://127.0.0.1:8080/jscoverage-shutdown
* http://127.0.0.1:8080/jscoverage-store
* http://127.0.0.1:8080/jscoverage-store/DIR
* http://127.0.0.1:8080/jscoverage-throbber.gif
* http://127.0.0.1:8080/jscoverage.css
* http://127.0.0.1:8080/jscoverage.html
* http://127.0.0.1:8080/jscoverage.js
* http://127.0.0.1:8080/missing
* http://127.0.0.1:8080/recursive/index.html
* http://127.0.0.1:8080/recursive/unix.txt
* http://127.0.0.1:8080/recursive/windows.txt
* http://127.0.0.1:8080/script.js
* http://127.0.0.1:8080/style.css
* http://127.0.0.1:8080/unix.txt
* http://127.0.0.1:8080/windows.txt
* http://127.0.0.1:8080/x
* http://127.0.0.1:8080/x.y
* http://127.0.0.1:8081/
* http://127.0.0.1:8081/1/1.js
* http://127.0.0.1:8081/1/2/2.js
* http://127.0.0.1:8081/script.js
* http://127.0.0.1:8082/1/1.js
* http://127.0.0.1:8082/1/2/2.js
* http://127.0.0.1:8082/script.js
* http://127.0.0.1:xyz/index.html
* http://localhost:8000/index.html